### PR TITLE
Add admin-bar deps to assets

### DIFF
--- a/classes/class-ep-debug-bar-elasticpress.php
+++ b/classes/class-ep-debug-bar-elasticpress.php
@@ -21,8 +21,8 @@ class EP_Debug_Bar_ElasticPress extends Debug_Bar_Panel {
 	 * Enqueue scripts for front end and admin
 	 */
 	public function enqueue_scripts_styles() {
-		wp_enqueue_script( 'debug-bar-elasticpress', plugins_url( '../assets/js/main.js' , __FILE__ ), array( 'jquery' ), EP_DEBUG_VERSION, true );
-		wp_enqueue_style( 'debug-bar-elasticpress', plugins_url( '../assets/css/main.css' , __FILE__ ), array(), EP_DEBUG_VERSION );
+		wp_enqueue_script( 'debug-bar-elasticpress', plugins_url( '../assets/js/main.js' , __FILE__ ), array( 'jquery', 'admin-bar' ), EP_DEBUG_VERSION, true );
+		wp_enqueue_style( 'debug-bar-elasticpress', plugins_url( '../assets/css/main.css' , __FILE__ ), array( 'admin-bar' ), EP_DEBUG_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
The plugin depends on debug bar/query monitor, and therefore the admin bar. While there's nothing _functionally_ requiring these dependencies be declared, it does improve compatibility with AMP plugin validation. [See this article.](https://weston.ruter.net/2019/09/24/integrating-with-amp-dev-mode-in-wordpress/) If you think there's a better way of approaching that (explicitly adding amp devmode tags within the plugin, for example, I'm open to that.